### PR TITLE
Update team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Our team is as follows:
 | ----------- | ----------------------- |
 | Kaizen      | Founder, Owner          |
 | Scott       | Administrator           |
+| FarCotton   | Administrator           |
 | Atmois      | Assistant Administrator |
-| FarCotton   | Assistant Administrator |
+| Hunter      | Assistant Administrator |
 | Estralia    | Senior Moderator        |
 | Exulan      | Senior Moderator        |
 | Vuks        | Senior Moderator        |
@@ -83,8 +84,8 @@ Our team is as follows:
 | Flatbread   | Moderator               |
 | Ilovecanada | Moderator               |
 | Jess        | Moderator               |
-| Lactose     | Moderator               |
-| Pockies     | Moderator               |
+| Ryna        | Moderator               |
+| Aimai       | Moderator               |
 | Storm       | Moderator               |
 
 ## 1.2 The Chain of Command

--- a/README.md
+++ b/README.md
@@ -73,19 +73,20 @@ Our team is as follows:
 | Name        | Role                    |
 | ----------- | ----------------------- |
 | Kaizen      | Founder, Owner          |
-| Scott       | Administrator           |
 | FarCotton   | Administrator           |
+| Scott       | Administrator           |
 | Atmois      | Assistant Administrator |
 | Hunter      | Assistant Administrator |
 | Estralia    | Senior Moderator        |
 | Exulan      | Senior Moderator        |
 | Vuks        | Senior Moderator        |
+| Aimai       | Moderator               |
 | Amilie      | Moderator               |
 | Flatbread   | Moderator               |
 | Ilovecanada | Moderator               |
 | Jess        | Moderator               |
+| Miyu        | Moderator               |
 | Ryna        | Moderator               |
-| Aimai       | Moderator               |
 | Storm       | Moderator               |
 
 ## 1.2 The Chain of Command


### PR DESCRIPTION
title

## Summary by Sourcery

Update the team member table in README to reflect current roles and moderators

Documentation:
- Promote FarCotton from Assistant Administrator to Administrator and add Hunter as the new Assistant Administrator
- Add new moderators Ryna and Aimai and Miyu
- Remove old moderators